### PR TITLE
Only use caduceus configured retry count

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ The following is an example request. Note: this is not a valid json because of t
     # (Optional) defaults to no sha1 hmac.
     "secret" : "secret",
 
-    # On failure how many times to retry the url for the event.
-    # (Optional) defaults to the configured value on the server
-    "max_retry_count": 3,
-
     # Alternative urls to send requests too. A list of server urls to use in
     # round robin for sending events.
     # (Optional) defaults to no alternative urls.

--- a/outboundSender.go
+++ b/outboundSender.go
@@ -176,11 +176,6 @@ func (osf OutboundSenderFactory) New() (obs OutboundSender, err error) {
 		return
 	}
 
-	// update default deliver retry count for sender
-	if osf.Listener.Config.MaxRetryCount != 0 {
-		osf.DeliveryRetries = osf.Listener.Config.MaxRetryCount
-	}
-
 	caduceusOutboundSender := &CaduceusOutboundSender{
 		id:               osf.Listener.Config.URL,
 		listener:         osf.Listener,
@@ -294,10 +289,6 @@ func (obs *CaduceusOutboundSender) Update(wh webhook.W) (err error) {
 
 	obs.events = events
 
-	// update default deliver retry count for sender
-	if wh.Config.MaxRetryCount != 0 {
-		obs.deliveryRetries = wh.Config.MaxRetryCount
-	}
 	obs.deliveryRetryMaxGauge.Set(float64(obs.deliveryRetries))
 
 	// if matcher list is empty set it nil for Queue() logic

--- a/outboundSender_test.go
+++ b/outboundSender_test.go
@@ -297,7 +297,6 @@ func TestAltURL(t *testing.T) {
 	}
 	w.Config.URL = "http://localhost:9999/foo"
 	w.Config.ContentType = "application/json"
-	w.Config.MaxRetryCount = 3
 	w.Config.AlternativeURLs = []string{
 		"http://localhost:9999/foo",
 		"http://localhost:9999/bar",
@@ -329,7 +328,7 @@ func TestAltURL(t *testing.T) {
 
 	obs.Shutdown(true)
 
-	assert.Equal(int32(4), trans.i)
+	assert.Equal(int32(2), trans.i)
 	for k, v := range urls {
 		assert.Equal(1, v, k)
 	}


### PR DESCRIPTION
Changes for  #167

Removes usage of Webhook's MaxRetryCount count config which is configured by consumer.