### PR TITLE
Improve Application Versioning

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/caduceus
+ARG VERSION=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
-RUN GO111MODULE=on go build -o caduceus_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o caduceus_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,12 +3,14 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/caduceus
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
-RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o caduceus_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o caduceus_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/caduceus
+ARG VERSION=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -o caduceus_linux_amd64
+RUN go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o caduceus_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -3,12 +3,14 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/caduceus
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o caduceus_linux_amd64
+RUN go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o caduceus_linux_amd64
 
 FROM alpine
 

--- a/deploy/packaging/caduceus.spec
+++ b/deploy/packaging/caduceus.spec
@@ -22,7 +22,7 @@ BuildRequires: golang >= 1.12
 The Xmidt API interface server.
 
 %build
-GO111MODULE=on go build -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
+GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=%{_version}" -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
 
 %install
 echo rm -rf %{buildroot}

--- a/main_test.go
+++ b/main_test.go
@@ -17,10 +17,85 @@
 package main
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
+}
+
+func TestPrintVersionInfo(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedOutput []string
+		overrideValues func()
+		lineCount      int
+	}{
+		{
+			"default",
+			[]string{
+				"caduceus:",
+				"version: \tundefined",
+				"go version: \tgo",
+				"built time: \tundefined",
+				"git commit: \tundefined",
+				"os/arch: \t",
+			},
+			func() {},
+			6,
+		},
+		{
+			"set values",
+			[]string{
+				"caduceus:",
+				"version: \t1.0.0\n",
+				"go version: \tgo",
+				"built time: \tsome time\n",
+				"git commit: \tgit sha\n",
+				"os/arch: \t",
+			},
+			func() {
+				Version = "1.0.0"
+				BuildTime = "some time"
+				GitCommit = "git sha"
+			},
+			6,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobals()
+			tc.overrideValues()
+			buf := &bytes.Buffer{}
+			printVersionInfo(buf)
+			count := 0
+			for {
+				line, err := buf.ReadString(byte('\n'))
+				if err != nil {
+					break
+				}
+				assert.Contains(t, line, tc.expectedOutput[count])
+				if strings.Contains(line, "\t") {
+					keyAndValue := strings.Split(line, "\t")
+					// The value after the tab should have more than 2 characters
+					// 1) the first character of the value and the new line
+					assert.True(t, len(keyAndValue[1]) > 2)
+				}
+				count++
+			}
+			assert.Equal(t, tc.lineCount, count)
+			resetGlobals()
+		})
+	}
+}
+
+func resetGlobals() {
+	Version = "undefined"
+	BuildTime = "undefined"
+	GitCommit = "undefined"
 }


### PR DESCRIPTION
This will allow for better bug reports and information the binary running.
This information can be retrieved upon providing the -v or --version
flag

Closes #170 

```
docker run --rm xmidt/caduceus:local -v
caduceus:
  version:      0.2.1+local
  go version:   go1.13.1
  built time:   2019-10-13 21:13:31
  git commit:   7d6eecc
  os/arch:      linux/amd64
```