### PR TITLE
Based on the linter findings this reads the body & closes it if there…

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,8 @@
 linters-settings:
   misspell:
     locale: US
+  goconst:
+    ignore-tests: true
 
 linters:
   enable:
@@ -31,6 +33,15 @@ issues:
     - path: outboundSender\.go
       # Accept sha1 for signature
       text: "G505:"
+
+    - path: outboundSender\.go
+      # Accept normal random function for determining a starting node
+      text: "G404:"
+
+    - path: outboundSender\.go
+      # The linter doesn't figure out that the closure below this code is valid.
+      source: ".*xhttp.RetryTransactor.*"
+      text: "response body must be closed"
 
     - path: outboundSender_test\.go
       # Accept sha1 for signature

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,8 +2,6 @@
 linters-settings:
   misspell:
     locale: US
-  goconst:
-    ignore-tests: true
 
 linters:
   enable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#246](https://github.com/xmidt-org/caduceus/pull/246)
 - Update buildtime format in Makefile to match RPM spec file. [#245](https://github.com/xmidt-org/caduceus/pull/245)
+- Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#246](https://github.com/xmidt-org/caduceus/pull/246)
+- Fix a bug where the response bodies were not cleaned up when informing a client of a failure. [#250](https://github.com/xmidt-org/caduceus/pull/250)
 
 ## [v0.4.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Update buildtime format in Makefile to match RPM spec file. [#245](https://github.com/xmidt-org/caduceus/pull/245)
-- Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#246](https://github.com/xmidt-org/caduceus/pull/246)
 - Fix a bug where the response bodies were not cleaned up when informing a client of a failure. [#250](https://github.com/xmidt-org/caduceus/pull/250)
+- Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#246](https://github.com/xmidt-org/caduceus/pull/246)
+- Update buildtime format in Makefile to match RPM spec file. [#245](https://github.com/xmidt-org/caduceus/pull/245)
 
 ## [v0.4.2]
 ### Fixed

--- a/http_test.go
+++ b/http_test.go
@@ -19,6 +19,8 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -98,6 +100,10 @@ func TestServerHandler(t *testing.T) {
 		resp := w.Result()
 
 		assert.Equal(http.StatusAccepted, resp.StatusCode)
+		if nil != resp.Body {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 		fakeHandler.AssertExpectations(t)
 	})
 }
@@ -145,6 +151,10 @@ func TestServerHandlerFixWrp(t *testing.T) {
 		resp := w.Result()
 
 		assert.Equal(http.StatusAccepted, resp.StatusCode)
+		if nil != resp.Body {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 		fakeHandler.AssertExpectations(t)
 	})
 }
@@ -180,6 +190,10 @@ func TestServerHandlerFull(t *testing.T) {
 		resp := w.Result()
 
 		assert.Equal(http.StatusServiceUnavailable, resp.StatusCode)
+		if nil != resp.Body {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 	})
 }
 
@@ -219,6 +233,10 @@ func TestServerEmptyPayload(t *testing.T) {
 		resp := w.Result()
 
 		assert.Equal(http.StatusBadRequest, resp.StatusCode)
+		if nil != resp.Body {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 	})
 }
 
@@ -260,6 +278,10 @@ func TestServerUnableToReadBody(t *testing.T) {
 		resp := w.Result()
 
 		assert.Equal(http.StatusBadRequest, resp.StatusCode)
+		if nil != resp.Body {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 	})
 }
 
@@ -301,5 +323,9 @@ func TestServerInvalidBody(t *testing.T) {
 		resp := w.Result()
 
 		assert.Equal(http.StatusBadRequest, resp.StatusCode)
+		if nil != resp.Body {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 	})
 }

--- a/outboundSender.go
+++ b/outboundSender.go
@@ -705,4 +705,9 @@ func (obs *CaduceusOutboundSender) queueOverflow() {
 	}
 
 	// Success
+
+	if nil != resp.Body {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}
 }

--- a/outboundSender_test.go
+++ b/outboundSender_test.go
@@ -307,11 +307,7 @@ func TestAltURL(t *testing.T) {
 
 	trans := &transport{}
 	trans.fn = func(req *http.Request, count int) (*http.Response, error) {
-		if _, ok := urls[req.URL.Path]; ok {
-			urls[req.URL.Path]++
-		} else {
-			urls[req.URL.Path] = 1
-		}
+		urls[req.URL.Path] += 1
 		return &http.Response{StatusCode: 429}, nil
 	}
 

--- a/primaryHandler_test.go
+++ b/primaryHandler_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,7 +102,10 @@ func TestMuxServerConfig(t *testing.T) {
 
 		router.ServeHTTP(w, req)
 		resp := w.Result()
-
+		if nil != resp.Body {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}
 		assert.Equal(http.StatusAccepted, resp.StatusCode)
 	})
 }


### PR DESCRIPTION
… is a body in the HTTP response.  This allows connection re-use and keeps our memory usage lower.  Additionally there were a few small simplifications added.