### PR TITLE
Incoming queue latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ _testmain.go
 # IDE files
 .idea/*
 
+# VSCode
+*.code-workspace
+.vscode/*
+
 caduceus
 .ignore
 

--- a/http_test.go
+++ b/http_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -69,7 +68,6 @@ func exampleRequest(msgType int, list ...string) *http.Request {
 }
 
 func TestServerHandler(t *testing.T) {
-	fmt.Print("TestingeServerHandler")
 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 
@@ -156,7 +154,6 @@ func TestServerHandler(t *testing.T) {
 }
 
 func TestServerHandlerFixWrp(t *testing.T) {
-	fmt.Printf("TestServerHandlerFixWrp")
 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 
@@ -218,7 +215,6 @@ func TestServerHandlerFixWrp(t *testing.T) {
 }
 
 func TestServerHandlerFull(t *testing.T) {
-	fmt.Printf("TestServerHandlerFull")
 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 
@@ -267,7 +263,6 @@ func TestServerHandlerFull(t *testing.T) {
 }
 
 func TestServerEmptyPayload(t *testing.T) {
-	fmt.Printf("TestServerEmptyPayLoad")
 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 
@@ -321,7 +316,6 @@ func TestServerEmptyPayload(t *testing.T) {
 }
 
 func TestServerUnableToReadBody(t *testing.T) {
-	fmt.Printf("TestServerUnableToReadBody")
 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 
@@ -377,7 +371,6 @@ func TestServerUnableToReadBody(t *testing.T) {
 }
 
 func TestServerInvalidBody(t *testing.T) {
-	fmt.Printf("TestServerInvalidBody")
 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 

--- a/http_test.go
+++ b/http_test.go
@@ -86,7 +86,7 @@ func TestServerHandler(t *testing.T) {
 			desc:              "TestServeHTTPHappyPath",
 			expectedResponse:  http.StatusAccepted,
 			request:           exampleRequest(4),
-			expectedEventType: "Unknown",
+			expectedEventType: "bob",
 			startTime:         date1,
 			endTime:           date2,
 		},
@@ -95,7 +95,7 @@ func TestServerHandler(t *testing.T) {
 			expectedResponse:      http.StatusBadRequest,
 			request:               exampleRequest(1),
 			throwStatusBadRequest: true,
-			expectedEventType:     "Unknown",
+			expectedEventType:     unknownEventType,
 			startTime:             date1,
 			endTime:               date2,
 		},
@@ -183,7 +183,7 @@ func TestServerHandlerFixWrp(t *testing.T) {
 	fakeModifiedWRPCount.On("Add", 1.0).Return().Once()
 
 	fakeHist := new(mockHistogram)
-	histogramFunctionCall := []string{"event", "Unknown"}
+	histogramFunctionCall := []string{"event", "bob"}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -233,7 +233,7 @@ func TestServerHandlerFull(t *testing.T) {
 	fakeQueueDepth.On("Add", mock.AnythingOfType("float64")).Return().Times(4)
 
 	fakeHist := new(mockHistogram)
-	histogramFunctionCall := []string{"event", "Unknown"}
+	histogramFunctionCall := []string{"event", unknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -288,7 +288,7 @@ func TestServerEmptyPayload(t *testing.T) {
 	fakeQueueDepth.On("Add", mock.AnythingOfType("float64")).Return().Times(4)
 
 	fakeHist := new(mockHistogram)
-	histogramFunctionCall := []string{"event", "Unknown"}
+	histogramFunctionCall := []string{"event", unknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -343,7 +343,7 @@ func TestServerUnableToReadBody(t *testing.T) {
 	fakeQueueDepth.On("Add", mock.AnythingOfType("float64")).Return().Times(4)
 
 	fakeHist := new(mockHistogram)
-	histogramFunctionCall := []string{"event", "Unknown"}
+	histogramFunctionCall := []string{"event", unknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -398,7 +398,7 @@ func TestServerInvalidBody(t *testing.T) {
 	fakeInvalidCount.On("Add", mock.AnythingOfType("float64")).Return().Once()
 
 	fakeHist := new(mockHistogram)
-	histogramFunctionCall := []string{"event", "Unknown"}
+	histogramFunctionCall := []string{"event", unknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -433,7 +433,7 @@ func TestHandlerUnsupportedMediaType(t *testing.T) {
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 
 	fakeHist := new(mockHistogram)
-	histogramFunctionCall := []string{"event", "Unknown"}
+	histogramFunctionCall := []string{"event", unknownEventType}
 	fakeLatency := date2.Sub(date1)
 
 	assert := assert.New(t)

--- a/metrics.go
+++ b/metrics.go
@@ -6,26 +6,26 @@ import (
 )
 
 const (
-	ErrorRequestBodyCounter         = "error_request_body_count"
-	EmptyRequestBodyCounter         = "empty_request_body_count"
-	ModifiedWRPCounter              = "modified_wrp_count"
-	DeliveryCounter                 = "delivery_count"
-	DeliveryRetryCounter            = "delivery_retry_count"
-	DeliveryRetryMaxGauge           = "delivery_retry_max"
-	SlowConsumerDroppedMsgCounter   = "slow_consumer_dropped_message_count"
-	SlowConsumerCounter             = "slow_consumer_cut_off_count"
-	IncomingQueueDepth              = "incoming_queue_depth"
-	IncomingEventTypeCounter        = "incoming_event_type_count"
-	DropsDueToInvalidPayload        = "drops_due_to_invalid_payload"
-	OutgoingQueueDepth              = "outgoing_queue_depths"
-	DropsDueToPanic                 = "drops_due_to_panic"
-	ConsumerRenewalTimeGauge        = "consumer_renewal_time"
-	ConsumerDeliverUntilGauge       = "consumer_deliver_until"
-	ConsumerDropUntilGauge          = "consumer_drop_until"
-	ConsumerDeliveryWorkersGauge    = "consumer_delivery_workers"
-	ConsumerMaxDeliveryWorkersGauge = "consumer_delivery_workers_max"
-	QueryDurationSecondsHistogram   = "query_duration_seconds_histogram"
-	IncomingQueueLatencyHistogram   = "incoming_queue_latency_histogram"
+	ErrorRequestBodyCounter               = "error_request_body_count"
+	EmptyRequestBodyCounter               = "empty_request_body_count"
+	ModifiedWRPCounter                    = "modified_wrp_count"
+	DeliveryCounter                       = "delivery_count"
+	DeliveryRetryCounter                  = "delivery_retry_count"
+	DeliveryRetryMaxGauge                 = "delivery_retry_max"
+	SlowConsumerDroppedMsgCounter         = "slow_consumer_dropped_message_count"
+	SlowConsumerCounter                   = "slow_consumer_cut_off_count"
+	IncomingQueueDepth                    = "incoming_queue_depth"
+	IncomingEventTypeCounter              = "incoming_event_type_count"
+	DropsDueToInvalidPayload              = "drops_due_to_invalid_payload"
+	OutgoingQueueDepth                    = "outgoing_queue_depths"
+	DropsDueToPanic                       = "drops_due_to_panic"
+	ConsumerRenewalTimeGauge              = "consumer_renewal_time"
+	ConsumerDeliverUntilGauge             = "consumer_deliver_until"
+	ConsumerDropUntilGauge                = "consumer_drop_until"
+	ConsumerDeliveryWorkersGauge          = "consumer_delivery_workers"
+	ConsumerMaxDeliveryWorkersGauge       = "consumer_delivery_workers_max"
+	QueryDurationSecondsHistogram         = "query_duration_seconds_histogram"
+	IncomingQueueLatencyHistogram_seconds = "incoming_queue_latency_histogram"
 )
 
 const (
@@ -150,7 +150,7 @@ func Metrics() []xmetrics.Metric {
 			Buckets:    []float64{0.0625, 0.125, .25, .5, 1, 5, 10, 20, 40, 80, 160},
 		},
 		{
-			Name:       IncomingQueueLatencyHistogram,
+			Name:       IncomingQueueLatencyHistogram_seconds,
 			Help:       "A histogram of latencies for the incoming queue.",
 			Type:       "histogram",
 			LabelNames: []string{"code"},

--- a/metrics.go
+++ b/metrics.go
@@ -33,6 +33,7 @@ const (
 	emptyUUIDReason        = "empty_uuid"
 	bothEmptyReason        = "empty_uuid_and_content_type"
 	networkError           = "network_err"
+	unknownEventType       = "unknown"
 )
 
 func Metrics() []xmetrics.Metric {

--- a/metrics.go
+++ b/metrics.go
@@ -25,6 +25,7 @@ const (
 	ConsumerDeliveryWorkersGauge    = "consumer_delivery_workers"
 	ConsumerMaxDeliveryWorkersGauge = "consumer_delivery_workers_max"
 	QueryDurationSecondsHistogram   = "query_duration_seconds_histogram"
+	IncomingQueueLatencyHistogram   = "incoming_queue_latency_histogram"
 )
 
 const (
@@ -145,6 +146,13 @@ func Metrics() []xmetrics.Metric {
 			Help:       "A histogram of latencies for queries.",
 			Type:       "histogram",
 			LabelNames: []string{"url", "code"},
+			Buckets:    []float64{0.0625, 0.125, .25, .5, 1, 5, 10, 20, 40, 80, 160},
+		},
+		{
+			Name:       IncomingQueueLatencyHistogram,
+			Help:       "A histogram of latencies for the incoming queue.",
+			Type:       "histogram",
+			LabelNames: []string{"code"},
 			Buckets:    []float64{0.0625, 0.125, .25, .5, 1, 5, 10, 20, 40, 80, 160},
 		},
 	}


### PR DESCRIPTION
- Added new latency metric to track time spent in the "incoming queue" (ie how long it took to decode and then try to queue in all outbound senders)
- Closes #319 