### PR TITLE
JWK Migration Release v0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [v0.6.7]
+## [v0.6.9]
 - Added latency metric, which Tracks the time spent waiting on outbound client URLs to respond. [#312](https://github.com/xmidt-org/caduceus/pull/312)
 - Dependency update, note vulnerabilities
   - github.com/hashicorp/consul/api v1.13.1 // indirect
@@ -205,8 +205,8 @@ fixed build upload
 ### Added
 - Initial creation
 
-[Unreleased]: https://github.com/xmidt-org/caduceus/compare/v0.6.7...HEAD
-[v0.6.6]: https://github.com/xmidt-org/caduceus/compare/v0.6.6...v0.6.7
+[Unreleased]: https://github.com/xmidt-org/caduceus/compare/v0.6.9...HEAD
+[v0.6.9]: https://github.com/xmidt-org/caduceus/compare/v0.6.6...v0.6.9
 [v0.6.6]: https://github.com/xmidt-org/caduceus/compare/v0.6.5...v0.6.6
 [v0.6.5]: https://github.com/xmidt-org/caduceus/compare/v0.6.4...v0.6.5
 [v0.6.4]: https://github.com/xmidt-org/caduceus/compare/v0.6.3...v0.6.4


### PR DESCRIPTION
What's included:

- Added latency metric, which Tracks the time spent waiting on outbound client URLs to respond. [#312](https://github.com/xmidt-org/caduceus/pull/312)
- Dependency update, note vulnerabilities
  - github.com/hashicorp/consul/api v1.13.1 // indirect
    Wasn't able to find much info about this one besides the following dep vulns
    - golang.org/x/net
      - https://nvd.nist.gov/vuln/detail/CVE-2021-33194
      - https://nvd.nist.gov/vuln/detail/CVE-2021-31525
      - https://nvd.nist.gov/vuln/detail/CVE-2021-44716
  - Introduces new vuln https://www.mend.io/vulnerability-database/CVE-2022-29526
  -  guardrails says github.com/gorilla/websocket v1.5.0 has a high vulnerability but no vulnerabilities have been filed
- JWT Migration #331 
  - updated to use clortho `Resolver` & `Refresher`
  - updated to use clortho `metrics` & `logging`
- Update ancla client initialization
- Update Config
  - Use [uber/zap](https://github.com/uber-go/zap) for clortho logging
  - Use [xmidt-org/sallust](https://github.com/xmidt-org/sallust) for the zap config unmarshalling 
  - Update auth config for clortho
  - Update ancla config