### PR TITLE
Feat/sink interface

### DIFF
--- a/caduceus_type.go
+++ b/caduceus_type.go
@@ -12,15 +12,6 @@ import (
 
 // Below is the struct we're using to contain the data from a provided config file
 // TODO: Try to figure out how to make bucket ranges configurable
-type CaduceusConfig struct {
-	AuthHeader       []string
-	NumWorkerThreads int
-	JobQueueSize     int
-	Sink             SinkConfig
-	JWTValidators    []JWTValidator
-	AllowInsecureTLS bool
-}
-
 type SinkConfig struct {
 	// The number of workers to assign to each SinkSender created.
 	NumWorkersPerSender int

--- a/listenerStub.go
+++ b/listenerStub.go
@@ -11,7 +11,6 @@ import (
 // This is a stub for the webhook and kafka listeners. This will be removed once the webhook-schema configuration is approved
 type Listener interface {
 	GetId() string
-	GetAddress() string
 	GetPartnerIds() []string
 	GetUntil() time.Time
 }
@@ -208,19 +207,11 @@ func (v1 *ListenerV1) GetPartnerIds() []string {
 	return v1.PartnerIds
 }
 
-func (v1 *ListenerV1) GetAddress() string {
-	return v1.Registration.Address
-}
-
 func (v1 *ListenerV1) GetUntil() time.Time {
 	return v1.Registration.Until
 }
 func (v2 *ListenerV2) GetId() string {
 	return v2.Registration.CanonicalName
-}
-
-func (v2 *ListenerV2) GetAddress() string {
-	return v2.Registration.Address
 }
 
 func (v2 *ListenerV2) GetPartnerIds() []string {

--- a/matcher.go
+++ b/matcher.go
@@ -23,14 +23,16 @@ func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{}, nil
 }
 
-type WebhookI interface {
+// move to subpackage and change to Interface
+type Matcher interface {
 	IsMatch(*wrp.Message) bool
 
 	//TODO: not sure if this will be functionality of all webhooks or just v1
 	//leaving for now - will make changes if running into roadblock with this
 	getUrls() *ring.Ring
 }
-type WebhookV1 struct {
+
+type MatcherV1 struct {
 	events  []*regexp.Regexp
 	matcher []*regexp.Regexp
 	urls    *ring.Ring
@@ -44,10 +46,10 @@ type CommonWebhook struct {
 
 // Update applies user configurable values for the outbound sender when a
 // webhook is registered
-func (w1 *WebhookV1) Update(l ListenerV1) error {
+func (m1 *MatcherV1) Update(l ListenerV1) error {
 
 	//TODO: don't believe the logger for webhook is being set anywhere just yet
-	w1.logger = w1.logger.With(zap.String("webhook.address", l.Registration.Address))
+	m1.logger = m1.logger.With(zap.String("webhook.address", l.Registration.Address))
 
 	if l.Registration.FailureURL != "" {
 		_, err := url.ParseRequestURI(l.Registration.FailureURL)
@@ -89,42 +91,42 @@ func (w1 *WebhookV1) Update(l ListenerV1) error {
 	for i := 0; i < urlCount; i++ {
 		_, err := url.Parse(l.Registration.Config.AlternativeURLs[i])
 		if err != nil {
-			w1.logger.Error("failed to update url", zap.Any("url", l.Registration.Config.AlternativeURLs[i]), zap.Error(err))
+			m1.logger.Error("failed to update url", zap.Any("url", l.Registration.Config.AlternativeURLs[i]), zap.Error(err))
 			return err
 		}
 	}
 
 	// write/update sink sender
-	w1.mutex.Lock()
-	defer w1.mutex.Unlock()
+	m1.mutex.Lock()
+	defer m1.mutex.Unlock()
 
-	w1.events = events
+	m1.events = events
 
 	//TODO: need to figure out how to set this
 
 	// if matcher list is empty set it nil for Queue() logic
-	w1.matcher = nil
+	m1.matcher = nil
 	if 0 < len(matcher) {
-		w1.matcher = matcher
+		m1.matcher = matcher
 	}
 
 	if urlCount == 0 {
-		w1.urls = ring.New(1)
-		w1.urls.Value = l.Registration.Config.ReceiverURL
+		m1.urls = ring.New(1)
+		m1.urls.Value = l.Registration.Config.ReceiverURL
 	} else {
 		ring := ring.New(urlCount)
 		for i := 0; i < urlCount; i++ {
 			ring.Value = l.Registration.Config.AlternativeURLs[i]
 			ring = ring.Next()
 		}
-		w1.urls = ring
+		m1.urls = ring
 	}
 
 	// Randomize where we start so all the instances don't synchronize
 	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	offset := rand.Intn(w1.urls.Len())
+	offset := rand.Intn(m1.urls.Len())
 	for 0 < offset {
-		w1.urls = w1.urls.Next()
+		m1.urls = m1.urls.Next()
 		offset--
 	}
 
@@ -132,11 +134,11 @@ func (w1 *WebhookV1) Update(l ListenerV1) error {
 
 }
 
-func (w1 *WebhookV1) IsMatch(msg *wrp.Message) bool {
-	w1.mutex.RLock()
-	events := w1.events
-	matcher := w1.matcher
-	w1.mutex.RUnlock()
+func (m1 *MatcherV1) IsMatch(msg *wrp.Message) bool {
+	m1.mutex.RLock()
+	events := m1.events
+	matcher := m1.matcher
+	m1.mutex.RUnlock()
 
 	var (
 		matchEvent  bool
@@ -149,7 +151,7 @@ func (w1 *WebhookV1) IsMatch(msg *wrp.Message) bool {
 		}
 	}
 	if !matchEvent {
-		w1.logger.Debug("destination regex doesn't match", zap.String("event.dest", msg.Destination))
+		m1.logger.Debug("destination regex doesn't match", zap.String("event.dest", msg.Destination))
 		return false
 	}
 
@@ -164,17 +166,17 @@ func (w1 *WebhookV1) IsMatch(msg *wrp.Message) bool {
 	}
 
 	if !matchDevice {
-		w1.logger.Debug("device regex doesn't match", zap.String("event.source", msg.Source))
+		m1.logger.Debug("device regex doesn't match", zap.String("event.source", msg.Source))
 		return false
 	}
 	return true
 }
 
-func (w1 *WebhookV1) getUrls() (urls *ring.Ring) {
-	urls = w1.urls
+func (m1 *MatcherV1) getUrls() (urls *ring.Ring) {
+	urls = m1.urls
 	// Move to the next URL to try 1st the next time.
 	// This is okay because we run a single dispatcher and it's the
 	// only one updating this field.
-	w1.urls = w1.urls.Next()
+	m1.urls = m1.urls.Next()
 	return
 }

--- a/sink.go
+++ b/sink.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/xmidt-org/wrp-go/v3"
+	"go.uber.org/zap"
+)
+
+type SinkI interface {
+	Update(Listener) error
+	Shutdown(bool)
+	Queue(*wrp.Message)
+}
+
+type Sink struct {
+}
+
+func (s *Sink) Update(l Listener) (err error) {
+	switch v := l.(type) {
+	case *ListenerV1:
+		m := &MatcherV1{}
+		if err = m.Update(*v); err != nil {
+			return
+		}
+		s.matcher = m
+	default:
+		err = fmt.Errorf("invalid listner")
+	}
+
+	s.renewalTimeGauge.Set(float64(time.Now().Unix()))
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.deliverUntil = l.GetUntil()
+	s.deliverUntilGauge.Set(float64(s.deliverUntil.Unix()))
+	s.deliveryRetryMaxGauge.Set(float64(s.deliveryRetries))
+
+	s.id = l.GetId()
+	s.listener = l
+	s.failureMessage.Original = l
+
+	// Update this here in case we make this configurable later
+	s.maxWorkersGauge.Set(float64(s.maxWorkers))
+
+	return
+}
+
+// Shutdown causes the CaduceusOutboundSender to stop its activities either gently or
+// abruptly based on the gentle parameter.  If gentle is false, all queued
+// messages will be dropped without an attempt to send made.
+func (s *Sink) Shutdown(gentle bool) {
+	if !gentle {
+		// need to close the channel we're going to replace, in case it doesn't
+		// have any events in it.
+		close(s.queue.Load().(chan *wrp.Message))
+		s.Empty(s.droppedExpiredCounter)
+	}
+	close(s.queue.Load().(chan *wrp.Message))
+	s.wg.Wait()
+
+	s.mutex.Lock()
+	s.deliverUntil = time.Time{}
+	s.deliverUntilGauge.Set(float64(s.deliverUntil.Unix()))
+	s.queueDepthGauge.Set(0) //just in case
+	s.mutex.Unlock()
+}
+
+// Queue is given a request to evaluate and optionally enqueue in the list
+// of messages to deliver.  The request is checked to see if it matches the
+// criteria before being accepted or silently dropped.
+// TODO: can pass in message along with webhook information
+func (s *Sink) Queue(msg *wrp.Message) {
+	s.mutex.RLock()
+	deliverUntil := s.deliverUntil
+	dropUntil := s.dropUntil
+	s.mutex.RUnlock()
+
+	now := time.Now()
+
+	if !s.isValidTimeWindow(now, dropUntil, deliverUntil) {
+		s.logger.Debug("invalid time window for event", zap.Any("now", now), zap.Any("dropUntil", dropUntil), zap.Any("deliverUntil", deliverUntil))
+		return
+	}
+
+	if !s.disablePartnerIDs {
+		if len(msg.PartnerIDs) == 0 {
+			msg.PartnerIDs = s.customPIDs
+		}
+		if !overlaps(s.listener.GetPartnerIds(), msg.PartnerIDs) {
+			s.logger.Debug("parter id check failed", zap.Strings("webhook.partnerIDs", s.listener.GetPartnerIds()), zap.Strings("event.partnerIDs", msg.PartnerIDs))
+			return
+		}
+		if ok := s.matcher.IsMatch(msg); !ok {
+			return
+		}
+
+	}
+
+	//TODO: this code will be changing will take away queue and send to the sink interface (not webhook interface)
+	select {
+	case s.queue.Load().(chan *wrp.Message) <- msg:
+		s.queueDepthGauge.Add(1.0)
+		s.logger.Debug("event added to outbound queue", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination))
+	default:
+		s.logger.Debug("queue full. event dropped", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination))
+		s.queueOverflow()
+		s.droppedQueueFullCounter.Add(1.0)
+	}
+}

--- a/sink.go
+++ b/sink.go
@@ -21,34 +21,37 @@ import (
 	"go.uber.org/zap"
 )
 
-type SinkI interface {
+type Sink interface {
 	Update(Listener) error
 	Send(*ring.Ring, string, string, *wrp.Message) error
 }
 
-type SinkWebhookV1 struct {
+type WebhookV1 struct {
 	id               string
 	deliveryInterval time.Duration
 	deliveryRetries  int
 	logger           *zap.Logger
+	//TODO: need to determine best way to add client and client middleware to WebhooV1
+	client           http.Client
+	clientMiddleware func(http.Client) http.Client
 }
 
-func NewSinkWebhookV1(s *SinkSender) {
-	v1 := &SinkWebhookV1{
+func NewWebhookV1(s *SinkSender) {
+	v1 := &WebhookV1{
 		id:               s.id,
 		deliveryInterval: s.deliveryInterval,
 		deliveryRetries:  s.deliveryRetries,
 	}
 	s.sink = v1
 }
-func (v1 *SinkWebhookV1) Update(l Listener) (err error) {
+func (v1 *WebhookV1) Update(l Listener) (err error) {
 	v1.id = l.GetId()
 	return nil
 }
 
 // worker is the routine that actually takes the queued messages and delivers
 // them to the listeners outside webpa
-func (v1 *SinkWebhookV1) Send(urls *ring.Ring, secret, acceptType string, msg *wrp.Message) error {
+func (v1 *WebhookV1) Send(urls *ring.Ring, secret, acceptType string, msg *wrp.Message) error {
 	defer func() {
 		if r := recover(); nil != r {
 			// s.droppedPanic.Add(1.0)
@@ -142,7 +145,7 @@ func (v1 *SinkWebhookV1) Send(urls *ring.Ring, secret, acceptType string, msg *w
 	return nil
 }
 
-func (v1 *SinkWebhookV1) addRunner(request *http.Request, event string) retry.Runner[*http.Response] {
+func (v1 *WebhookV1) addRunner(request *http.Request, event string) retry.Runner[*http.Response] {
 	runner, _ := retry.NewRunner[*http.Response](
 		retry.WithPolicyFactory[*http.Response](retry.Config{
 			Interval:   v1.deliveryInterval,
@@ -153,7 +156,7 @@ func (v1 *SinkWebhookV1) addRunner(request *http.Request, event string) retry.Ru
 	return runner
 }
 
-func (v1 *SinkWebhookV1) updateRequest(urls *ring.Ring) func(*http.Request) *http.Request {
+func (v1 *WebhookV1) updateRequest(urls *ring.Ring) func(*http.Request) *http.Request {
 	return func(request *http.Request) *http.Request {
 		urls = urls.Next()
 		tmp, err := url.Parse(urls.Value.(string))
@@ -165,7 +168,7 @@ func (v1 *SinkWebhookV1) updateRequest(urls *ring.Ring) func(*http.Request) *htt
 	}
 }
 
-func (v1 *SinkWebhookV1) onAttempt(request *http.Request, event string) retry.OnAttempt[*http.Response] {
+func (v1 *WebhookV1) onAttempt(request *http.Request, event string) retry.OnAttempt[*http.Response] {
 
 	return func(attempt retry.Attempt[*http.Response]) {
 		if attempt.Retries > 0 {

--- a/sink.go
+++ b/sink.go
@@ -1,112 +1,177 @@
 package main
 
 import (
+	"bytes"
+	"container/ring"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/xmidt-org/retry"
+	"github.com/xmidt-org/retry/retryhttp"
 	"github.com/xmidt-org/wrp-go/v3"
+	"github.com/xmidt-org/wrp-go/v3/wrphttp"
 	"go.uber.org/zap"
 )
 
 type SinkI interface {
 	Update(Listener) error
-	Shutdown(bool)
-	Queue(*wrp.Message)
+	Send(*ring.Ring, string, string, *wrp.Message) error
 }
 
-type Sink struct {
+type SinkWebhookV1 struct {
+	id               string
+	deliveryInterval time.Duration
+	deliveryRetries  int
+	logger           *zap.Logger
 }
 
-func (s *Sink) Update(l Listener) (err error) {
-	switch v := l.(type) {
-	case *ListenerV1:
-		m := &MatcherV1{}
-		if err = m.Update(*v); err != nil {
-			return
-		}
-		s.matcher = m
-	default:
-		err = fmt.Errorf("invalid listner")
+func NewSinkWebhookV1(s *SinkSender) {
+	v1 := &SinkWebhookV1{
+		id:               s.id,
+		deliveryInterval: s.deliveryInterval,
+		deliveryRetries:  s.deliveryRetries,
 	}
-
-	s.renewalTimeGauge.Set(float64(time.Now().Unix()))
-
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	s.deliverUntil = l.GetUntil()
-	s.deliverUntilGauge.Set(float64(s.deliverUntil.Unix()))
-	s.deliveryRetryMaxGauge.Set(float64(s.deliveryRetries))
-
-	s.id = l.GetId()
-	s.listener = l
-	s.failureMessage.Original = l
-
-	// Update this here in case we make this configurable later
-	s.maxWorkersGauge.Set(float64(s.maxWorkers))
-
-	return
+	s.sink = v1
+}
+func (v1 *SinkWebhookV1) Update(l Listener) (err error) {
+	v1.id = l.GetId()
+	return nil
 }
 
-// Shutdown causes the CaduceusOutboundSender to stop its activities either gently or
-// abruptly based on the gentle parameter.  If gentle is false, all queued
-// messages will be dropped without an attempt to send made.
-func (s *Sink) Shutdown(gentle bool) {
-	if !gentle {
-		// need to close the channel we're going to replace, in case it doesn't
-		// have any events in it.
-		close(s.queue.Load().(chan *wrp.Message))
-		s.Empty(s.droppedExpiredCounter)
-	}
-	close(s.queue.Load().(chan *wrp.Message))
-	s.wg.Wait()
+// worker is the routine that actually takes the queued messages and delivers
+// them to the listeners outside webpa
+func (v1 *SinkWebhookV1) Send(urls *ring.Ring, secret, acceptType string, msg *wrp.Message) error {
+	defer func() {
+		if r := recover(); nil != r {
+			// s.droppedPanic.Add(1.0)
+			v1.logger.Error("goroutine send() panicked", zap.String("id", v1.id), zap.Any("panic", r))
+		}
+		// s.workers.Release()
+		// s.currentWorkersGauge.Add(-1.0)
+	}()
 
-	s.mutex.Lock()
-	s.deliverUntil = time.Time{}
-	s.deliverUntilGauge.Set(float64(s.deliverUntil.Unix()))
-	s.queueDepthGauge.Set(0) //just in case
-	s.mutex.Unlock()
+	payload := msg.Payload
+	body := payload
+	var payloadReader *bytes.Reader
+
+	// Use the internal content type unless the accept type is wrp
+	contentType := msg.ContentType
+	switch acceptType {
+	case "wrp", wrp.MimeTypeMsgpack, wrp.MimeTypeWrp:
+		// WTS - We should pass the original, raw WRP event instead of
+		// re-encoding it.
+		contentType = wrp.MimeTypeMsgpack
+		buffer := bytes.NewBuffer([]byte{})
+		encoder := wrp.NewEncoder(buffer, wrp.Msgpack)
+		encoder.Encode(msg)
+		body = buffer.Bytes()
+	}
+	payloadReader = bytes.NewReader(body)
+
+	req, err := http.NewRequest("POST", urls.Value.(string), payloadReader)
+	if err != nil {
+		// Report drop
+		// s.droppedInvalidConfig.Add(1.0)
+		v1.logger.Error("Invalid URL", zap.String("url", urls.Value.(string)), zap.String("id", v1.id), zap.Error(err))
+		return err
+	}
+
+	req.Header.Set("Content-Type", contentType)
+
+	// Add x-Midt-* headers
+	wrphttp.AddMessageHeaders(req.Header, msg)
+
+	// Provide the old headers for now
+	req.Header.Set("X-Webpa-Event", strings.TrimPrefix(msg.Destination, "event:"))
+	req.Header.Set("X-Webpa-Transaction-Id", msg.TransactionUUID)
+
+	// Add the device id without the trailing service
+	id, _ := wrp.ParseDeviceID(msg.Source)
+	req.Header.Set("X-Webpa-Device-Id", string(id))
+	req.Header.Set("X-Webpa-Device-Name", string(id))
+
+	// Apply the secret
+
+	if secret != "" {
+		s := hmac.New(sha1.New, []byte(secret))
+		s.Write(body)
+		sig := fmt.Sprintf("sha1=%s", hex.EncodeToString(s.Sum(nil)))
+		req.Header.Set("X-Webpa-Signature", sig)
+	}
+
+	// find the event "short name"
+	event := msg.FindEventStringSubMatch()
+
+	// Send it
+	v1.logger.Debug("attempting to send event", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination))
+	client, _ := retryhttp.NewClient(
+		// retryhttp.WithHTTPClient(s.clientMiddleware(s.client)),
+		retryhttp.WithRunner(v1.addRunner(req, event)),
+		retryhttp.WithRequesters(v1.updateRequest(urls)),
+	)
+	resp, err := client.Do(req)
+
+	code := "failure"
+	logger := v1.logger
+	if err != nil {
+		// Report failure
+		// s.droppedNetworkErrCounter.Add(1.0)
+		logger.Error("Dropped Network Error", zap.Error(err))
+		return err
+	} else {
+		// Report Result
+		code = strconv.Itoa(resp.StatusCode)
+
+		// read until the response is complete before closing to allow
+		// connection reuse
+		if resp.Body != nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}
+	// s.deliveryCounter.With(prometheus.Labels{UrlLabel: s.id, CodeLabel: code, EventLabel: event}).Add(1.0)
+	logger.Debug("event sent-ish", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination), zap.String("code", code), zap.String("url", req.URL.String()))
+	return nil
 }
 
-// Queue is given a request to evaluate and optionally enqueue in the list
-// of messages to deliver.  The request is checked to see if it matches the
-// criteria before being accepted or silently dropped.
-// TODO: can pass in message along with webhook information
-func (s *Sink) Queue(msg *wrp.Message) {
-	s.mutex.RLock()
-	deliverUntil := s.deliverUntil
-	dropUntil := s.dropUntil
-	s.mutex.RUnlock()
+func (v1 *SinkWebhookV1) addRunner(request *http.Request, event string) retry.Runner[*http.Response] {
+	runner, _ := retry.NewRunner[*http.Response](
+		retry.WithPolicyFactory[*http.Response](retry.Config{
+			Interval:   v1.deliveryInterval,
+			MaxRetries: v1.deliveryRetries,
+		}),
+		retry.WithOnAttempt[*http.Response](v1.onAttempt(request, event)),
+	)
+	return runner
+}
 
-	now := time.Now()
-
-	if !s.isValidTimeWindow(now, dropUntil, deliverUntil) {
-		s.logger.Debug("invalid time window for event", zap.Any("now", now), zap.Any("dropUntil", dropUntil), zap.Any("deliverUntil", deliverUntil))
-		return
+func (v1 *SinkWebhookV1) updateRequest(urls *ring.Ring) func(*http.Request) *http.Request {
+	return func(request *http.Request) *http.Request {
+		urls = urls.Next()
+		tmp, err := url.Parse(urls.Value.(string))
+		if err != nil {
+			v1.logger.Error("failed to update url", zap.String(UrlLabel, urls.Value.(string)), zap.Error(err))
+		}
+		request.URL = tmp
+		return request
 	}
+}
 
-	if !s.disablePartnerIDs {
-		if len(msg.PartnerIDs) == 0 {
-			msg.PartnerIDs = s.customPIDs
-		}
-		if !overlaps(s.listener.GetPartnerIds(), msg.PartnerIDs) {
-			s.logger.Debug("parter id check failed", zap.Strings("webhook.partnerIDs", s.listener.GetPartnerIds()), zap.Strings("event.partnerIDs", msg.PartnerIDs))
-			return
-		}
-		if ok := s.matcher.IsMatch(msg); !ok {
-			return
+func (v1 *SinkWebhookV1) onAttempt(request *http.Request, event string) retry.OnAttempt[*http.Response] {
+
+	return func(attempt retry.Attempt[*http.Response]) {
+		if attempt.Retries > 0 {
+			// s.deliveryRetryCounter.With(prometheus.Labels{UrlLabel: v1.id, EventLabel: event}).Add(1.0)
+			v1.logger.Debug("retrying HTTP transaction", zap.String("url", request.URL.String()), zap.Error(attempt.Err), zap.Int("retry", attempt.Retries+1), zap.Int("statusCode", attempt.Result.StatusCode))
 		}
 
-	}
-
-	//TODO: this code will be changing will take away queue and send to the sink interface (not webhook interface)
-	select {
-	case s.queue.Load().(chan *wrp.Message) <- msg:
-		s.queueDepthGauge.Add(1.0)
-		s.logger.Debug("event added to outbound queue", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination))
-	default:
-		s.logger.Debug("queue full. event dropped", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination))
-		s.queueOverflow()
-		s.droppedQueueFullCounter.Add(1.0)
 	}
 }

--- a/sinkSender.go
+++ b/sinkSender.go
@@ -13,9 +13,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,11 +20,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/xmidt-org/retry"
-	"github.com/xmidt-org/retry/retryhttp"
 	"github.com/xmidt-org/webpa-common/v2/semaphore"
 	"github.com/xmidt-org/wrp-go/v3"
-	"github.com/xmidt-org/wrp-go/v3/wrphttp"
 )
 
 // failureText is human readable text for the failure message
@@ -70,6 +64,7 @@ type SinkSender struct {
 	workers           semaphore.Interface
 	logger            *zap.Logger
 	sink              SinkI
+	client            http.Client
 	clientMiddleware  func(Client) Client
 	failureMessage    FailureMessage
 	listener          Listener
@@ -139,6 +134,7 @@ func NewSinkSender(sw *SinkWrapper, l Listener) (sender *SinkSender, err error) 
 		disablePartnerIDs: sw.config.DisablePartnerIDs,
 		clientMiddleware:  sw.clientMiddleware,
 	}
+
 	sender.CreateMetrics(sw.metrics)
 	sender.queueDepthGauge.Set(0)
 	sender.currentWorkersGauge.Set(0)
@@ -167,6 +163,7 @@ func (s *SinkSender) Update(l Listener) (err error) {
 			return
 		}
 		s.matcher = m
+		NewSinkWebhookV1(s)
 	default:
 		err = fmt.Errorf("invalid listner")
 	}
@@ -440,141 +437,11 @@ Loop:
 			s.workers.Acquire()
 			s.currentWorkersGauge.Add(1.0)
 
-			go s.send(urls, secret, accept, msg)
+			go s.sink.Send(urls, secret, accept, msg)
 		}
 	}
 	for i := 0; i < s.maxWorkers; i++ {
 		s.workers.Acquire()
-	}
-}
-
-//TODO:
-
-// worker is the routine that actually takes the queued messages and delivers
-// them to the listeners outside webpa
-func (s *SinkSender) send(urls *ring.Ring, secret, acceptType string, msg *wrp.Message) {
-	defer func() {
-		if r := recover(); nil != r {
-			s.droppedPanic.Add(1.0)
-			s.logger.Error("goroutine send() panicked", zap.String("id", s.id), zap.Any("panic", r))
-		}
-		s.workers.Release()
-		s.currentWorkersGauge.Add(-1.0)
-	}()
-
-	payload := msg.Payload
-	body := payload
-	var payloadReader *bytes.Reader
-
-	// Use the internal content type unless the accept type is wrp
-	contentType := msg.ContentType
-	switch acceptType {
-	case "wrp", wrp.MimeTypeMsgpack, wrp.MimeTypeWrp:
-		// WTS - We should pass the original, raw WRP event instead of
-		// re-encoding it.
-		contentType = wrp.MimeTypeMsgpack
-		buffer := bytes.NewBuffer([]byte{})
-		encoder := wrp.NewEncoder(buffer, wrp.Msgpack)
-		encoder.Encode(msg)
-		body = buffer.Bytes()
-	}
-	payloadReader = bytes.NewReader(body)
-
-	req, err := http.NewRequest("POST", urls.Value.(string), payloadReader)
-	if nil != err {
-		// Report drop
-		s.droppedInvalidConfig.Add(1.0)
-		s.logger.Error("Invalid URL", zap.String("url", urls.Value.(string)), zap.String("id", s.id), zap.Error(err))
-		return
-	}
-
-	req.Header.Set("Content-Type", contentType)
-
-	// Add x-Midt-* headers
-	wrphttp.AddMessageHeaders(req.Header, msg)
-
-	// Provide the old headers for now
-	req.Header.Set("X-Webpa-Event", strings.TrimPrefix(msg.Destination, "event:"))
-	req.Header.Set("X-Webpa-Transaction-Id", msg.TransactionUUID)
-
-	// Add the device id without the trailing service
-	id, _ := wrp.ParseDeviceID(msg.Source)
-	req.Header.Set("X-Webpa-Device-Id", string(id))
-	req.Header.Set("X-Webpa-Device-Name", string(id))
-
-	// Apply the secret
-
-	if secret != "" {
-		s := hmac.New(sha1.New, []byte(secret))
-		s.Write(body)
-		sig := fmt.Sprintf("sha1=%s", hex.EncodeToString(s.Sum(nil)))
-		req.Header.Set("X-Webpa-Signature", sig)
-	}
-
-	// find the event "short name"
-	event := msg.FindEventStringSubMatch()
-
-	// Send it
-	s.logger.Debug("attempting to send event", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination))
-	client, _ := retryhttp.NewClient(
-		// retryhttp.WithHTTPClient(s.clientMiddleware(s.client)),
-		retryhttp.WithRunner(s.addRunner(req, event)),
-		retryhttp.WithRequesters(s.updateRequest(urls)),
-	)
-	resp, err := client.Do(req)
-
-	code := "failure"
-	logger := s.logger
-	if nil != err {
-		// Report failure
-		s.droppedNetworkErrCounter.Add(1.0)
-		logger = s.logger.With(zap.Error(err))
-	} else {
-		// Report Result
-		code = strconv.Itoa(resp.StatusCode)
-
-		// read until the response is complete before closing to allow
-		// connection reuse
-		if nil != resp.Body {
-			io.Copy(io.Discard, resp.Body)
-			resp.Body.Close()
-		}
-	}
-	s.deliveryCounter.With(prometheus.Labels{UrlLabel: s.id, CodeLabel: code, EventLabel: event}).Add(1.0)
-	logger.Debug("event sent-ish", zap.String("event.source", msg.Source), zap.String("event.destination", msg.Destination), zap.String("code", code), zap.String("url", req.URL.String()))
-}
-
-func (s *SinkSender) addRunner(request *http.Request, event string) retry.Runner[*http.Response] {
-	runner, _ := retry.NewRunner[*http.Response](
-		retry.WithPolicyFactory[*http.Response](retry.Config{
-			Interval:   s.deliveryInterval,
-			MaxRetries: s.deliveryRetries,
-		}),
-		retry.WithOnAttempt[*http.Response](s.onAttempt(request, event)),
-	)
-	return runner
-}
-
-func (s *SinkSender) updateRequest(urls *ring.Ring) func(*http.Request) *http.Request {
-	return func(request *http.Request) *http.Request {
-		urls = urls.Next()
-		tmp, err := url.Parse(urls.Value.(string))
-		if err != nil {
-			s.logger.Error("failed to update url", zap.String(UrlLabel, urls.Value.(string)), zap.Error(err))
-		}
-		request.URL = tmp
-		return request
-	}
-}
-
-func (s *SinkSender) onAttempt(request *http.Request, event string) retry.OnAttempt[*http.Response] {
-
-	return func(attempt retry.Attempt[*http.Response]) {
-		if attempt.Retries > 0 {
-			s.deliveryRetryCounter.With(prometheus.Labels{UrlLabel: s.id, EventLabel: event}).Add(1.0)
-			s.logger.Debug("retrying HTTP transaction", zap.String("url", request.URL.String()), zap.Error(attempt.Err), zap.Int("retry", attempt.Retries+1), zap.Int("statusCode", attempt.Result.StatusCode))
-		}
-
 	}
 }
 

--- a/sinkSender.go
+++ b/sinkSender.go
@@ -63,12 +63,11 @@ type SinkSender struct {
 	wg                sync.WaitGroup
 	workers           semaphore.Interface
 	logger            *zap.Logger
-	sink              SinkI
-	client            http.Client
-	clientMiddleware  func(Client) Client
-	failureMessage    FailureMessage
-	listener          Listener
-	matcher           Matcher
+	sink              Sink
+	// failureMessage is sent during a queue overflow.
+	failureMessage FailureMessage
+	listener       Listener
+	matcher        Matcher
 	SinkMetrics
 }
 
@@ -132,7 +131,6 @@ func NewSinkSender(sw *SinkWrapper, l Listener) (sender *SinkSender, err error) 
 		},
 		customPIDs:        sw.config.CustomPIDs,
 		disablePartnerIDs: sw.config.DisablePartnerIDs,
-		clientMiddleware:  sw.clientMiddleware,
 	}
 
 	sender.CreateMetrics(sw.metrics)
@@ -163,7 +161,7 @@ func (s *SinkSender) Update(l Listener) (err error) {
 			return
 		}
 		s.matcher = m
-		NewSinkWebhookV1(s)
+		NewWebhookV1(s)
 	default:
 		err = fmt.Errorf("invalid listner")
 	}


### PR DESCRIPTION
1.  sinkwrapper client interface will be replace by the  sink interface
2. the sink interface will have the following funcs (`update(l Listener)`, `send(urls *ring.Ring, secret, acceptType string, msg *wrp.Message)`)
3. the webhook abstraction will be renamed to something like matcher since it's main purpose is to match incoming messages to desired events or wrp field regex