### PR TITLE
Main rebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@5bc4b83f25ff4c944cd6253ba189e50d1997ab3c # v4.1.0
     with:
       release-type:          program
-      release-docker:        true
+      release-docker:        false
       release-docker-latest: true
       release-docker-major:  true
       release-docker-minor:  true

--- a/internal/client/httpClient_test.go
+++ b/internal/client/httpClient_test.go
@@ -19,7 +19,6 @@ package client
 // 	errTest := errors.New("test error")
 // 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 // 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
-
 // 	tests := []struct {
 // 		description      string
 // 		startTime        time.Time
@@ -33,32 +32,34 @@ package client
 // 			description:  "Success",
 // 			startTime:    date1,
 // 			endTime:      date2,
-// 			expectedCode: "200",
+// 			expectedCode: strconv.Itoa(http.StatusOK),
 // 			request:      exampleRequest(1),
 // 			expectedErr:  nil,
 // 			expectedResponse: &http.Response{
-// 				StatusCode: 200,
+// 				StatusCode: http.StatusOK,
 // 			},
 // 		},
 // 		{
 // 			description:  "503 Service Unavailable",
 // 			startTime:    date1,
 // 			endTime:      date2,
-// 			expectedCode: "503",
+// 			expectedCode: strconv.Itoa(http.StatusServiceUnavailable),
 // 			request:      exampleRequest(1),
 // 			expectedErr:  nil,
 // 			expectedResponse: &http.Response{
-// 				StatusCode: 503,
+// 				StatusCode: http.StatusServiceUnavailable,
 // 			},
 // 		},
 // 		{
-// 			description:      "Network Error",
-// 			startTime:        date1,
-// 			endTime:          date2,
-// 			expectedCode:     "network_err",
-// 			request:          exampleRequest(1),
-// 			expectedErr:      errTest,
-// 			expectedResponse: nil,
+// description:  "Network Error",
+// startTime:    date1,
+// endTime:      date2,
+// expectedCode: strconv.Itoa(http.StatusServiceUnavailable),
+// request:      exampleRequest(1),
+// expectedErr:  errors.New(genericDoReason),
+// expectedResponse: &http.Response{
+// 	StatusCode: http.StatusServiceUnavailable,
+// },
 // 		},
 // 	}
 
@@ -69,7 +70,7 @@ package client
 // 			fakeTime := mockTime(tc.startTime, tc.endTime)
 // 			fakeHandler := new(mockHandler)
 // 			fakeHist := new(mockHistogram)
-// 			histogramFunctionCall := []string{"code", tc.expectedCode}
+// 			histogramFunctionCall := []string{metrics.UrlLabel, tc.request.URL.String(), metrics.ReasonLabel, metrics.GetDoErrReason(tc.expectedErr), metrics.CodeLabel, tc.expectedCode}
 // 			fakeLatency := date2.Sub(date1)
 // 			fakeHist.On("With", histogramFunctionCall).Return().Once()
 // 			fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()

--- a/internal/handler/http.go
+++ b/internal/handler/http.go
@@ -154,7 +154,7 @@ func (sh *ServerHandler) handleRequest(msg *wrp.Message) {
 
 func (sh *ServerHandler) recordQueueLatencyToHistogram(startTime time.Time, eventType string) {
 	endTime := sh.now()
-	sh.telemetry.IncomingQueueLatency.With(prometheus.Labels{"event": eventType}).Observe(endTime.Sub(startTime).Seconds())
+	sh.telemetry.IncomingQueueLatency.With(prometheus.Labels{metrics.EventLabel: eventType}).Observe(endTime.Sub(startTime).Seconds())
 }
 
 func (sh *ServerHandler) fixWrp(msg *wrp.Message) *wrp.Message {
@@ -179,7 +179,7 @@ func (sh *ServerHandler) fixWrp(msg *wrp.Message) *wrp.Message {
 	}
 
 	if reason != "" {
-		sh.telemetry.ModifiedWRPCount.With(prometheus.Labels{"reason": reason}).Add(1.0)
+		sh.telemetry.ModifiedWRPCount.With(prometheus.Labels{metrics.ReasonLabel: reason}).Add(1.0)
 	}
 
 	return msg

--- a/internal/handler/http_test.go
+++ b/internal/handler/http_test.go
@@ -109,7 +109,7 @@ func TestServerHandler(t *testing.T) {
 
 		fakeTime := mocks.Time(tc.startTime, tc.endTime)
 		fakeHist := new(mocks.Histogram)
-		histogramFunctionCall := []string{"event", tc.expectedEventType}
+		histogramFunctionCall := []string{metrics.EventLabel, tc.expectedEventType}
 		fakeLatency := date2.Sub(date1)
 		fakeHist.On("With", histogramFunctionCall).Return().Once()
 		fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -167,11 +167,11 @@ func TestServerHandlerFixWrp(t *testing.T) {
 	fakeIncomingContentTypeCount.On("Add", 1.0).Return()
 
 	fakeModifiedWRPCount := new(mocks.Counter)
-	fakeModifiedWRPCount.On("With", []string{"reason", metrics.BothEmptyReason}).Return(fakeIncomingContentTypeCount).Once()
+	fakeModifiedWRPCount.On("With", []string{metrics.ReasonLabel, metrics.BothEmptyReason}).Return(fakeIncomingContentTypeCount).Once()
 	fakeModifiedWRPCount.On("Add", 1.0).Return().Once()
 
 	fakeHist := new(mocks.Histogram)
-	histogramFunctionCall := []string{"event", "bob"}
+	histogramFunctionCall := []string{metrics.EventLabel, "bob"}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -220,7 +220,7 @@ func TestServerHandlerFull(t *testing.T) {
 	fakeQueueDepth.On("Add", mock.AnythingOfType("float64")).Return().Times(4)
 
 	fakeHist := new(mocks.Histogram)
-	histogramFunctionCall := []string{"event", metrics.UnknownEventType}
+	histogramFunctionCall := []string{metrics.EventLabel, metrics.UnknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -275,7 +275,7 @@ func TestServerEmptyPayload(t *testing.T) {
 	fakeQueueDepth.On("Add", mock.AnythingOfType("float64")).Return().Times(4)
 
 	fakeHist := new(mocks.Histogram)
-	histogramFunctionCall := []string{"event", metrics.UnknownEventType}
+	histogramFunctionCall := []string{metrics.EventLabel, metrics.UnknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -331,7 +331,7 @@ func TestServerUnableToReadBody(t *testing.T) {
 	fakeQueueDepth.On("Add", mock.AnythingOfType("float64")).Return().Times(4)
 
 	fakeHist := new(mocks.Histogram)
-	histogramFunctionCall := []string{"event", metrics.UnknownEventType}
+	histogramFunctionCall := []string{metrics.EventLabel, metrics.UnknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -387,7 +387,7 @@ func TestServerInvalidBody(t *testing.T) {
 	fakeInvalidCount.On("Add", mock.AnythingOfType("float64")).Return().Once()
 
 	fakeHist := new(mocks.Histogram)
-	histogramFunctionCall := []string{"event", metrics.UnknownEventType}
+	histogramFunctionCall := []string{metrics.EventLabel, metrics.UnknownEventType}
 	fakeLatency := date2.Sub(date1)
 	fakeHist.On("With", histogramFunctionCall).Return().Once()
 	fakeHist.On("Observe", fakeLatency.Seconds()).Return().Once()
@@ -423,7 +423,7 @@ func TestHandlerUnsupportedMediaType(t *testing.T) {
 	date1 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
 	date2 := time.Date(2021, time.Month(2), 21, 1, 10, 30, 45, time.UTC)
 
-	histogramFunctionCall := []string{"event", metrics.UnknownEventType}
+	histogramFunctionCall := []string{metrics.EventLabel, metrics.UnknownEventType}
 	fakeLatency := date2.Sub(date1)
 
 	assert := assert.New(t)

--- a/internal/sink/matcher.go
+++ b/internal/sink/matcher.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/xmidt-org/caduceus/internal/metrics"
 	"github.com/xmidt-org/wrp-go/v3"
 	"go.uber.org/zap"
 )
@@ -93,7 +94,7 @@ func (m1 *MatcherV1) Update(l ListenerV1) error {
 	for i := 0; i < urlCount; i++ {
 		_, err := url.Parse(l.Registration.Config.AlternativeURLs[i])
 		if err != nil {
-			m1.logger.Error("failed to update url", zap.Any("url", l.Registration.Config.AlternativeURLs[i]), zap.Error(err))
+			m1.logger.Error("failed to update url", zap.Any(metrics.UrlLabel, l.Registration.Config.AlternativeURLs[i]), zap.Error(err))
 			return err
 		}
 	}
@@ -160,7 +161,7 @@ func (m1 *MatcherV1) IsMatch(msg *wrp.Message) bool {
 	if matcher != nil {
 		matchDevice = false
 		for _, deviceRegex := range matcher {
-			if deviceRegex.MatchString(msg.Source) {
+			if deviceRegex.MatchString(msg.Source) || deviceRegex.MatchString(strings.TrimPrefix(msg.Destination, "event:")) {
 				matchDevice = true
 				break
 			}

--- a/internal/sink/sinkSender.go
+++ b/internal/sink/sinkSender.go
@@ -84,7 +84,7 @@ type SinkMetrics struct {
 	droppedCutoffCounter             prometheus.Counter
 	droppedExpiredCounter            prometheus.Counter
 	droppedExpiredBeforeQueueCounter prometheus.Counter
-	droppedNetworkErrCounter         prometheus.Counter
+	droppedMessage                   prometheus.Counter
 	droppedInvalidConfig             prometheus.Counter
 	droppedPanic                     prometheus.Counter
 	cutOffCounter                    prometheus.Counter
@@ -454,7 +454,7 @@ func (s *sender) CreateMetrics(m metrics.Metrics) {
 	s.droppedExpiredBeforeQueueCounter = m.SlowConsumerDroppedMsgCounter.With(prometheus.Labels{metrics.UrlLabel: s.id, metrics.ReasonLabel: "expired_before_queueing"})
 	s.droppedCutoffCounter = m.SlowConsumerDroppedMsgCounter.With(prometheus.Labels{metrics.UrlLabel: s.id, metrics.ReasonLabel: "cut_off"})
 	s.droppedInvalidConfig = m.SlowConsumerDroppedMsgCounter.With(prometheus.Labels{metrics.UrlLabel: s.id, metrics.ReasonLabel: "invalid_config"})
-	s.droppedNetworkErrCounter = m.SlowConsumerDroppedMsgCounter.With(prometheus.Labels{metrics.UrlLabel: s.id, metrics.ReasonLabel: metrics.NetworkError})
+	s.droppedMessage = m.SlowConsumerDroppedMsgCounter.With(prometheus.Labels{metrics.UrlLabel: s.id, metrics.ReasonLabel: metrics.NetworkError})
 	s.droppedPanic = m.DropsDueToPanic.With(prometheus.Labels{metrics.UrlLabel: s.id})
 	s.queueDepthGauge = m.OutgoingQueueDepth.With(prometheus.Labels{metrics.UrlLabel: s.id})
 	s.renewalTimeGauge = m.ConsumerRenewalTimeGauge.With(prometheus.Labels{metrics.UrlLabel: s.id})

--- a/internal/sink/sinkSender_test.go
+++ b/internal/sink/sinkSender_test.go
@@ -59,8 +59,8 @@ package sink
 // // //  3. Trigger the On method on that "mockMetric" with various different cases of that metric,
 // // //     in both senderWrapper_test.go and outboundSender_test.go
 // // //     i.e:
-// // //     case 1: On("With", []string{"event", iot}
-// // //     case 2: On("With", []string{"event", unknown}
+// // //     case 1: On("With", []string{metrics.EventLabel, iot}
+// // //     case 2: On("With", []string{metrics.EventLabel, unknown}
 // // //  4. Mimic the metric behavior using On:
 // // //     fakeSlow.On("Add", 1.0).Return()
 // // func simpleFactorySetup(trans *transport, cutOffPeriod time.Duration, matcher []string) *OutboundSenderFactory {
@@ -89,34 +89,34 @@ package sink
 
 // // 	// test dc metric
 // // 	fakeDC := new(mockCounter)
-// // 	fakeDC.On("With", []string{"url", w.Webhook.Config.URL, "code", "200", "event", "test"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "200", "event", "iot"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "200", "event", "unknown"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "failure", "event", "iot"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "event", "test"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "event", "iot"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "event", "unknown"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "201"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "202"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "204"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "429", "event", "iot"}).Return(fakeDC).
-// // 		On("With", []string{"url", w.Webhook.Config.URL, "code", "failure"}).Return(fakeDC)
+// // 	fakeDC.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "200", metrics.EventLabel, "test"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "200", metrics.EventLabel, "iot"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "200", metrics.EventLabel, "unknown"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "failure", metrics.EventLabel, "iot"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.EventLabel, "test"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.EventLabel, "iot"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.EventLabel, "unknown"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "201"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "202"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "204"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "429", metrics.EventLabel, "iot"}).Return(fakeDC).
+// // 		On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "failure"}).Return(fakeDC)
 // // 	fakeDC.On("Add", 1.0).Return()
 // // 	fakeDC.On("Add", 0.0).Return()
 
 // // 	// test slow metric
 // // 	fakeSlow := new(mockCounter)
-// // 	fakeSlow.On("With", []string{"url", w.Webhook.Config.URL}).Return(fakeSlow)
+// // 	fakeSlow.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL}).Return(fakeSlow)
 // // 	fakeSlow.On("Add", 1.0).Return()
 
 // // 	// test dropped metric
 // // 	fakeDroppedSlow := new(mockCounter)
-// // 	fakeDroppedSlow.On("With", []string{"url", w.Webhook.Config.URL, "reason", "queue_full"}).Return(fakeDroppedSlow)
-// // 	fakeDroppedSlow.On("With", []string{"url", w.Webhook.Config.URL, "reason", "cut_off"}).Return(fakeDroppedSlow)
-// // 	fakeDroppedSlow.On("With", []string{"url", w.Webhook.Config.URL, "reason", "expired"}).Return(fakeDroppedSlow)
-// // 	fakeDroppedSlow.On("With", []string{"url", w.Webhook.Config.URL, "reason", "expired_before_queueing"}).Return(fakeDroppedSlow)
-// // 	fakeDroppedSlow.On("With", []string{"url", w.Webhook.Config.URL, "reason", "invalid_config"}).Return(fakeDroppedSlow)
-// // 	fakeDroppedSlow.On("With", []string{"url", w.Webhook.Config.URL, "reason", "network_err"}).Return(fakeDroppedSlow)
+// // 	fakeDroppedSlow.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.ReasonLabel, "queue_full"}).Return(fakeDroppedSlow)
+// // 	fakeDroppedSlow.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.ReasonLabel, "cut_off"}).Return(fakeDroppedSlow)
+// // 	fakeDroppedSlow.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.ReasonLabel, "expired"}).Return(fakeDroppedSlow)
+// // 	fakeDroppedSlow.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.ReasonLabel, "expired_before_queueing"}).Return(fakeDroppedSlow)
+// // 	fakeDroppedSlow.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.ReasonLabel, "invalid_config"}).Return(fakeDroppedSlow)
+// // 	fakeDroppedSlow.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.ReasonLabel, "network_err"}).Return(fakeDroppedSlow)
 // // 	fakeDroppedSlow.On("Add", mock.Anything).Return()
 
 // // 	// IncomingContentType cases
@@ -129,18 +129,18 @@ package sink
 
 // // 	// QueueDepth case
 // // 	fakeQdepth := new(mockGauge)
-// // 	fakeQdepth.On("With", []string{"url", w.Webhook.Config.URL}).Return(fakeQdepth)
+// // 	fakeQdepth.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL}).Return(fakeQdepth)
 // // 	fakeQdepth.On("Add", 1.0).Return().On("Add", -1.0).Return()
 
 // // 	// DropsDueToPanic case
 // // 	fakePanicDrop := new(mockCounter)
-// // 	fakePanicDrop.On("With", []string{"url", w.Webhook.Config.URL}).Return(fakePanicDrop)
+// // 	fakePanicDrop.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL}).Return(fakePanicDrop)
 // // 	fakePanicDrop.On("Add", 1.0).Return()
 
 // // 	// Fake Latency
 // // 	fakeLatency := new(mockHistogram)
-// // 	fakeLatency.On("With", []string{"url", w.Webhook.Config.URL, "code", "200"}).Return(fakeLatency)
-// // 	fakeLatency.On("With", []string{"url", w.Webhook.Config.URL}).Return(fakeLatency)
+// // 	fakeLatency.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL, metrics.CodeLabel, "200"}).Return(fakeLatency)
+// // 	fakeLatency.On("With", []string{metrics.UrlLabel, w.Webhook.Config.URL}).Return(fakeLatency)
 // // 	fakeLatency.On("Observe", 1.0).Return()
 
 // // 	// Build a registry and register all fake metrics, these are synymous with the metrics in

--- a/internal/sink/sinkWrapper.go
+++ b/internal/sink/sinkWrapper.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/kit/metrics/provider"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xmidt-org/caduceus/internal/client"
 	"github.com/xmidt-org/caduceus/internal/metrics"
@@ -155,7 +156,7 @@ func (w *wrapper) Update(list []Listener) {
 			var err error
 
 			listener := inValue.Listener
-			metricWrapper, err := client.NewMetricWrapper(time.Now, w.metrics.QueryLatency, inValue.ID)
+			metricWrapper, err := client.NewMetricWrapper(time.Now, w.metrics.QueryLatency.With(prometheus.Labels{metrics.UrlLabel: inValue.ID}))
 
 			if err != nil {
 				continue
@@ -184,7 +185,7 @@ func (w *wrapper) Queue(msg *wrp.Message) {
 	w.mutex.RLock()
 	defer w.mutex.RUnlock()
 
-	w.eventType.With(prometheus.Labels{"event": msg.FindEventStringSubMatch()}).Add(1)
+	w.eventType.With(prometheus.Labels{metrics.EventLabel: msg.FindEventStringSubMatch()}).Add(1)
 
 	for _, v := range w.senders {
 		v.Queue(msg)

--- a/internal/sink/sinkWrapper_test.go
+++ b/internal/sink/sinkWrapper_test.go
@@ -49,42 +49,42 @@ func (t *swTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // 	fakeGauge := new(mockGauge)
 // 	fakeGauge.On("Add", 1.0).Return().
 // 		On("Add", -1.0).Return().
-// 		//On("With", []string{"url", "unknown"}).Return(fakeGauge).
-// 		On("With", []string{"url", "http://localhost:8888/foo"}).Return(fakeGauge).
-// 		On("With", []string{"url", "http://localhost:9999/foo"}).Return(fakeGauge)
+// 		//On("With", []string{metrics.UrlLabel, "unknown"}).Return(fakeGauge).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo"}).Return(fakeGauge).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo"}).Return(fakeGauge)
 
 // 	// Fake Latency
 // 	fakeLatency := new(mockHistogram)
-// 	fakeLatency.On("With", []string{"url", "http://localhost:8888/foo", "code", "200"}).Return(fakeLatency)
-// 	fakeLatency.On("With", []string{"url", "http://localhost:9999/foo", "code", "200"}).Return(fakeLatency)
-// 	fakeLatency.On("With", []string{"url", "http://localhost:8888/foo"}).Return(fakeLatency)
-// 	fakeLatency.On("With", []string{"url", "http://localhost:9999/foo"}).Return(fakeLatency)
+// 	fakeLatency.On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.CodeLabel, "200"}).Return(fakeLatency)
+// 	fakeLatency.On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.CodeLabel, "200"}).Return(fakeLatency)
+// 	fakeLatency.On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo"}).Return(fakeLatency)
+// 	fakeLatency.On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo"}).Return(fakeLatency)
 // 	fakeLatency.On("Observe", 1.0).Return()
 
 // 	fakeIgnore := new(mockCounter)
 // 	fakeIgnore.On("Add", 1.0).Return().On("Add", 0.0).Return().
-// 		On("With", []string{"url", "http://localhost:8888/foo"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "event", "unknown"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "event", "unknown"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "reason", "cut_off"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "reason", "queue_full"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "reason", "expired"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "reason", "expired_before_queueing"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "reason", "network_err"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "reason", "invalid_config"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "reason", "cut_off"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "reason", "queue_full"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "reason", "expired"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "reason", "expired_before_queueing"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "reason", "network_err"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "reason", "invalid_config"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:8888/foo", "code", "200", "event", "unknown"}).Return(fakeIgnore).
-// 		On("With", []string{"url", "http://localhost:9999/foo", "code", "200", "event", "unknown"}).Return(fakeIgnore).
-// 		On("With", []string{"event", "iot"}).Return(fakeIgnore).
-// 		On("With", []string{"event", "test/extra-stuff"}).Return(fakeIgnore).
-// 		On("With", []string{"event", "bob/magic/dog"}).Return(fakeIgnore).
-// 		On("With", []string{"event", "unknown"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.EventLabel, "unknown"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.EventLabel, "unknown"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.ReasonLabel, "cut_off"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.ReasonLabel, "queue_full"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.ReasonLabel, "expired"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.ReasonLabel, "expired_before_queueing"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.ReasonLabel, "network_err"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.ReasonLabel, "invalid_config"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.ReasonLabel, "cut_off"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.ReasonLabel, "queue_full"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.ReasonLabel, "expired"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.ReasonLabel, "expired_before_queueing"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.ReasonLabel, "network_err"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.ReasonLabel, "invalid_config"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:8888/foo", metrics.CodeLabel, "200", metrics.EventLabel, "unknown"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.UrlLabel, "http://localhost:9999/foo", metrics.CodeLabel, "200", metrics.EventLabel, "unknown"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.EventLabel, "iot"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.EventLabel, "test/extra-stuff"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.EventLabel, "bob/magic/dog"}).Return(fakeIgnore).
+// 		On("With", []string{metrics.EventLabel, "unknown"}).Return(fakeIgnore).
 // 		On("With", []string{"content_type", "msgpack"}).Return(fakeIgnore).
 // 		On("With", []string{"content_type", "json"}).Return(fakeIgnore).
 // 		On("With", []string{"content_type", "http"}).Return(fakeIgnore).

--- a/routes.go
+++ b/routes.go
@@ -81,6 +81,7 @@ func provideCoreOption(server string, in RoutesIn) arrangehttp.Option[http.Serve
 				otelmux.WithPropagators(in.Tracing.Propagator()),
 			}
 
+
 			// TODO: should probably customize things a bit
 			mux.Use(recovery.Middleware(recovery.WithStatusCode(555)), otelmux.Middleware("server_primary", options...),
 				candlelight.EchoFirstTraceNodeInfo(in.Tracing.Propagator(), true))


### PR DESCRIPTION
What's Included:
https://github.com/xmidt-org/caduceus/pull/463 - added nolint fix
https://github.com/xmidt-org/caduceus/pull/461 - labels already changed to 'LabelName'Label; updated any spots where it wasn’t changed; updated httpClient.go; updated metrics.go; updated sink.go (outboundSender.go); updated senderWrapper.go; updated test files
https://github.com/xmidt-org/caduceus/pull/457 - go version already up to date; added in the ci.yaml and matcher change
https://github.com/xmidt-org/caduceus/pull/447 - already using 0.0.21 version and added middleware already being used