### PR TITLE
patch: remove `make test release` from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ARG BUILDTIME
 
 RUN apk add --no-cache --no-progress \
     ca-certificates \
-    make \
     curl \
     git \
     openssh \
@@ -25,8 +24,6 @@ RUN mkdir -p /go/bin && \
     sha1sum /go/bin/spruce
 
 COPY . .
-
-RUN make test release
 
 ##########################
 # Build the final image.


### PR DESCRIPTION
looks like `upx caduceus` is failing during `make test release`

```
                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2020
UPX 3.96        Markus Oberhumer, Laszlo Molnar & John Reiser   Jan 23rd 2020

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
upx: caduceus: UnknownExecutableFormatException
```