### PR TITLE
patch: remove an instance of panic silencing and add missing labels to `DeliveryCounter` and `QueryDurationHistogram`

### DIFF
--- a/http.go
+++ b/http.go
@@ -5,6 +5,7 @@ package main
 import (
 	"io"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -107,7 +108,8 @@ func (sh *ServerHandler) ServeHTTP(response http.ResponseWriter, request *http.R
 		logger.Debug("Strings must be UTF-8.")
 		return
 	}
-	eventType = msg.FindEventStringSubMatch()
+	// since eventType is only used to enrich metrics and logging, remove invalid UTF-8 characters from the URL
+	eventType = strings.ToValidUTF8(msg.FindEventStringSubMatch(), "")
 
 	sh.caduceusHandler.HandleRequest(0, sh.fixWrp(msg))
 

--- a/metrics.go
+++ b/metrics.go
@@ -174,12 +174,12 @@ func Metrics(tf *touchstone.Factory) (ServerHandlerMetrics, SenderWrapperMetrics
 		Name:    QueryDurationHistogram,
 		Help:    "A histogram of latencies for queries.",
 		Buckets: []float64{0.0625, 0.125, .25, .5, 1, 5, 10, 20, 40, 80, 160},
-	}, urlLabel, codeLabel)
+	}, urlLabel, codeLabel, reasonLabel)
 	errs = errors.Join(errs, err)
 	deliveryCounter, err := tf.NewCounterVec(prometheus.CounterOpts{
 		Name: DeliveryCounter,
 		Help: "Count of delivered messages to a url with a status code",
-	}, urlLabel, eventLabel, codeLabel)
+	}, urlLabel, reasonLabel, eventLabel, codeLabel)
 	errs = errors.Join(errs, err)
 	deliveryRetryCounter, err := tf.NewCounterVec(prometheus.CounterOpts{
 		Name: DeliveryRetryCounter,

--- a/outboundSender_test.go
+++ b/outboundSender_test.go
@@ -100,7 +100,7 @@ func simpleFactorySetup(trans *transport, cutOffPeriod time.Duration, matcher []
 	// test dc metric
 	fakeDC := new(mockCounter)
 	fakeDC.On("With", prometheus.Labels{urlLabel: w.Webhook.Config.URL, codeLabel: "200", eventLabel: "test", reasonLabel: noErrReason}).Return(fakeDC).
-		On("With", prometheus.Labels{urlLabel: w.Webhook.Config.URL, codeLabel: "200", eventLabel: "test\xedoops", reasonLabel: noErrReason}).Return(fakeDC).
+		On("With", prometheus.Labels{urlLabel: w.Webhook.Config.URL, codeLabel: "200", eventLabel: "testoops", reasonLabel: noErrReason}).Return(fakeDC).
 		On("With", prometheus.Labels{urlLabel: w.Webhook.Config.URL, codeLabel: "200", eventLabel: "iot", reasonLabel: noErrReason}).Return(fakeDC).
 		On("With", prometheus.Labels{urlLabel: w.Webhook.Config.URL, codeLabel: messageDroppedCode, eventLabel: "iot", reasonLabel: dnsErrReason}).Return(fakeDC).
 		On("With", prometheus.Labels{urlLabel: w.Webhook.Config.URL, codeLabel: "200", eventLabel: "unknown"}).Return(fakeDC).
@@ -492,16 +492,16 @@ func TestSimpleWrpWithWildcardMatchers(t *testing.T) {
 	r4.Destination = "event:test"
 	obs.Queue(r4)
 
-	/* This will panic. */
+	// test Invaild UTF8
 	r5 := simpleRequestWithPartnerIDs()
 	r5.TransactionUUID = "1234"
 	r5.Source = "mac:112233445560"
-	r5.Destination = "event:test\xedoops"
+	r5.Destination = "event:test\xed"
 	obs.Queue(r5)
 
 	obs.Shutdown(true)
 
-	assert.Equal(int32(4), trans.i)
+	assert.Equal(int32(5), trans.i)
 }
 
 /*


### PR DESCRIPTION
This pr does to things:

- patch an instance of panic silencing
  - introduced in https://github.com/xmidt-org/caduceus/pull/152
- add missing labels to `DeliveryCounter` and `QueryDurationHistogram`
  - this was missed due to the panic snoozing instance we're now patching