### PR TITLE
workflows: Bump shared-go workflows to v4.9.4.

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   release:
-    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@7c30bbc9c553a4282e562bc404640598a2a9714e # v4.9.3
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@465824a64b3ff83b02aa8b77c419211249b2a84a # v4.9.4
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ on:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@7c30bbc9c553a4282e562bc404640598a2a9714e # v4.9.3
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@465824a64b3ff83b02aa8b77c419211249b2a84a # v4.9.4
     with:
       release-type:          program
-      release-arch-arm64:    true
       release-arch-amd64:    true
+      release-arch-arm64:    true
       release-docker:        true
       release-docker-latest: true
       release-docker-major:  true
@@ -33,5 +33,5 @@ jobs:
         .release/docker
         LICENSE
         NOTICE
-      yaml-lint-skip:        false
+      yaml-lint-skip: false
     secrets: inherit


### PR DESCRIPTION
## What's Changing
- Bump shared-go workflows to v4.9.4.
- Add auto-release